### PR TITLE
Updates benchmarks to reify DOM.

### DIFF
--- a/benchmark/codegen-create/codegen-marko-vdom.js
+++ b/benchmark/codegen-create/codegen-marko-vdom.js
@@ -50,7 +50,7 @@ module.exports = function(node) {
 
     codegen(node, 0);
 
-    return 'return ' + code + '\n';
+    return 'return ' + code + '.actualize(document)\n';
 };
 
 module.exports.generateInitCode = function(node, html) {

--- a/benchmark/codegen-create/codegen-react.js
+++ b/benchmark/codegen-create/codegen-react.js
@@ -67,5 +67,14 @@ module.exports = function(node) {
         }
     }
 
-    return 'return ' + codegen(node, 0) + '\n';
+    var id = node.id;
+    var selector = "";
+
+    if (id) {
+        selector = 'document.getElementById(\'' + id + '\')';
+    } else {
+        selector = 'document.getElementById(\'todoapp\')';
+    }
+
+    return 'return ReactDOM.render(' + codegen(node, 0) + ', ' + selector + ');\n';
 };

--- a/benchmark/index.html
+++ b/benchmark/index.html
@@ -91,6 +91,7 @@
         </div>
     </section>
     <script src="https://unpkg.com/react@15.3.1/dist/react.min.js"></script>
+    <script src="https://unpkg.com/react-dom@15.3.1/dist/react-dom.min.js"></script>
     <script src="../dist/marko-vdom-umd.js"></script>
     <script src="../node_modules/lodash/lodash.js"></script>
     <script src="../node_modules/benchmark/benchmark.js"></script>


### PR DESCRIPTION
The [benchmark results](https://github.com/marko-js/marko-vdom/blob/master/docs/benchmark-results.md) for this library currently rely on an apples-to-oranges comparison. This patch updates the tests to cause each library to *actually* create DOM.